### PR TITLE
Changes for rails >= 5

### DIFF
--- a/lib/prevent_destroy_if_any.rb
+++ b/lib/prevent_destroy_if_any.rb
@@ -24,7 +24,7 @@ class ActiveRecord::Base
             :associated_objects => available_associations.join(', ')
           )
         )
-        false
+        throw :abort
       end
     end
   end

--- a/lib/prevent_destroy_if_any/version.rb
+++ b/lib/prevent_destroy_if_any/version.rb
@@ -1,3 +1,3 @@
 module PreventDestroyIfAny
-  VERSION = "0.2"
+  VERSION = "1.0"
 end


### PR DESCRIPTION
For Rails  5 and above, returning **false** won't halt the callback chain. we need to use `throw :abort`